### PR TITLE
use first decoded token for prefix

### DIFF
--- a/gpt_2_simple/gpt_2.py
+++ b/gpt_2_simple/gpt_2.py
@@ -381,7 +381,7 @@ def generate(sess,
             generated += 1
             gen_text = enc.decode(out[i])
             if prefix:
-                gen_text = prefix[0] + gen_text
+                gen_text = enc.decode(context_tokens[:1]) + gen_text
             if truncate:
                 truncate_esc = re.escape(truncate)
                 if prefix and not include_prefix:


### PR DESCRIPTION
instead of first character, since first token could be more than one character in length.

I had some text where the first token of the prefix was more than a single character, e.g. `'amy'`, so generating:

```python
gpt2.generate(sess, prefix="amy:")
```

would produce:

```
a: word
```

instead of

```
amy: word
```

`context_tokens` in this case was just two tokens: `['amy', ':']`.
