### PR TITLE
Fix bug in using custom `checkpoint_dir`

### DIFF
--- a/gpt_2_simple/gpt_2.py
+++ b/gpt_2_simple/gpt_2.py
@@ -799,6 +799,7 @@ def cmd_generate(nfiles, nsamples, folder,
 
         generate_to_file(sess,
                          run_name=run_name,
+                         checkpoint_dir=checkpoint_dir,
                          destination_path=gen_file,
                          length=length,
                          temperature=temperature,


### PR DESCRIPTION
If you finetune to a custom checkpoint_dir and then try to generate by referencing the same checkpoint_dir, an error gets thrown.  

The issue is that https://github.com/minimaxir/gpt-2-simple/blob/master/gpt_2_simple/gpt_2.py#L486 will always use the default `checkpoint_dir='checkpoint'` arg when called from https://github.com/minimaxir/gpt-2-simple/blob/master/gpt_2_simple/gpt_2.py#L800 with CLI usage.
