### PR TITLE
Added the ability to load a checkpoint other than the latest one

### DIFF
--- a/gpt_2_simple/gpt_2.py
+++ b/gpt_2_simple/gpt_2.py
@@ -362,6 +362,7 @@ def finetune(sess,
 
 
 def load_gpt2(sess,
+              checkpoint='latest',
               run_name="run1",
               checkpoint_dir="checkpoint",
               model_name=None,
@@ -388,7 +389,11 @@ def load_gpt2(sess,
 
     output = model.model(hparams=hparams, X=context, gpus=gpus)
 
-    ckpt = tf.train.latest_checkpoint(checkpoint_path)
+    if checkpoint=='latest':
+        ckpt = tf.train.latest_checkpoint(checkpoint_path)
+    else:
+        ckpt = os.path.join(checkpoint_path,checkpoint)
+
     saver = tf.compat.v1.train.Saver(allow_empty=True)
     sess.run(tf.compat.v1.global_variables_initializer())
 


### PR DESCRIPTION
As of now, you cannot, to my knowledge, load any checkpoint in `gpt2.load_gpt2()` besides the latest one. This seems odd, since one reason to checkpoint (besides hedging against the training crashing on accident) is to get a sense of performance throughout training. This PR solves this.