### PR TITLE
Update to fix bug for csv files with real commas in text

### DIFF
--- a/gpt_2_simple/src/load_dataset.py
+++ b/gpt_2_simple/src/load_dataset.py
@@ -36,7 +36,7 @@ def load_dataset(enc, path, combine):
                 fp.readline()   # skip header
                 reader = csv.reader(fp)
                 for row in reader:
-                    raw_text += start_token + row[0] + end_token + "\n"
+                    raw_text += start_token + ''.join(row) + end_token + "\n"
         else:
             # Plain text
             with open(path, 'r', encoding='utf8', errors='ignore') as fp:


### PR DESCRIPTION
Currently the load_dataset method will load the following csv row example: "I ate pie, ice cream, and cookies\n" in line 37 into reader list as `reader=[["I` ate pie", "ice cream", "and cookies"]]` due to the commas read as columns delimiters. 

When `reader[0]` is iterated as row in line 39 only` row[0]`(I ate pie) is taken which would yield `"<|startoftext|>I ate pie"<|endoftext|>"`
This is because the commas created multiple list items in row. 

Proposed change is to join each entire row list to use full text from each csv row. in this case `''.join(row)` yields `"<|startoftext|>I ate pie ice cream and cookies"<|endoftext|>"` as it compresses the list into a single string. I have tested both of these scenarios in the code base as well.