### PR TITLE
Created a fix for my issue https://github.com/minimaxir/gpt-2-simple/…

### DIFF
--- a/gpt_2_simple/gpt_2.py
+++ b/gpt_2_simple/gpt_2.py
@@ -615,7 +615,8 @@ def copy_file_from_gdrive(file_path):
     """Copies a file from a mounted Google Drive."""
     is_mounted()
 
-    shutil.copyfile("/content/drive/My Drive/" + file_path, file_path)
+    file_name = os.path.split(file_path)[1]
+    shutil.copyfile("/content/drive/My Drive/" + file_path, file_name)
 
 
 def is_gpt2_downloaded(model_dir='models', model_name='124M'):


### PR DESCRIPTION
https://github.com/minimaxir/gpt-2-simple/issues/226

Using `copy_file_from_gdrive` with a file path doesn't work - only a file name, forcing the developer to move large files into their drive root dir for use in colab. 