### PR TITLE
Ability to load npz files with newer numpy version

### DIFF
--- a/gpt_2_simple/src/load_dataset.py
+++ b/gpt_2_simple/src/load_dataset.py
@@ -26,7 +26,7 @@ def load_dataset(enc, path, combine):
     for path in tqdm.tqdm(paths):
         if path.endswith('.npz'):
             # Pre-encoded
-            with np.load(path) as npz:
+            with np.load(path,allow_pickle=True) as npz:
                 for item in npz.files:
                     token_chunks.append(npz[item])
         elif path.endswith('.csv'):


### PR DESCRIPTION
**Problem Statement :** 

npz files do not load with Newer numpy versions > 1.16

**The Fix : **
This is done by editing the load_dataset.py file by specifying the allow_pickle parameter to be True which allows the npz file to be loaded
