### PR TITLE
-Bugfix for failing load_dataset.py when there is an empty line in CS…

### DIFF
--- a/gpt_2_simple/src/load_dataset.py
+++ b/gpt_2_simple/src/load_dataset.py
@@ -36,7 +36,8 @@ def load_dataset(enc, path, combine):
                 fp.readline()   # skip header
                 reader = csv.reader(fp)
                 for row in reader:
-                    raw_text += start_token + row[0] + end_token + "\n"
+                    if row != []:
+                        raw_text += start_token + row[0] + end_token + "\n"
         else:
             # Plain text
             with open(path, 'r', encoding='utf8', errors='ignore') as fp:


### PR DESCRIPTION
I have realised that load_dataset.py fails if there is an empty string exist in loaded CSV file. That causes script to give the following error:
raw_text += start_token + row[0] + end_token + "\n"
IndexError: list index out of range

Problem was fixed after this commit.