### PR TITLE
Changed hard coded length value for variable

### DIFF
--- a/gpt_2_simple/gpt_2.py
+++ b/gpt_2_simple/gpt_2.py
@@ -461,7 +461,7 @@ def generate(sess,
 
     output = sample.sample_sequence(
         hparams=hparams,
-        length=min(length, 1023 - (len(context_tokens) if prefix else 0)),
+        length=min(length, length - (len(context_tokens) if prefix else 0)),
         start_token=enc.encoder['<|endoftext|>'] if not prefix else None,
         context=context if prefix else None,
         batch_size=batch_size,


### PR DESCRIPTION
Value of length was hard coded to 1023. This made the generator return 1023 - len(context) tokens when using a context instead of requested tokens - len(context).